### PR TITLE
Update CANN CI status

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ The ONNXRuntime source code is from `main` branch of `microsoft/onnxruntime` and
 
 ### Known Issue
 
+##### Issue #2 [Open] 
+Update on 2023.07.17  
+PR [#16506](https://github.com/microsoft/onnxruntime/pull/16506) changed the public constructor function `MLFloat16(uint16_t x)` to private, and added a public function `MLFloat16::FromBits(uint16_t x)` in the file `include/onnxruntime/core/framework/float16.h`, which broke the CANN CI. This has been fixed by PR [#16733](https://github.com/microsoft/onnxruntime/pull/16733) by replacing the constructor function `MLFloat16()` with the public member function `FromBits()` in the file `onnxruntime/core/providers/cann/cann_common.cc`, but is waiting for upstream merge.
+
 ##### Issue #1 [Closed] 
-Updated on 2023.07.06  
+Update on 2023.07.06  
 This [PR](https://github.com/microsoft/onnxruntime/pull/15833) refactored the ExecutionProvider API for memory management, and broke the CANN EP build. This has been fixed by this [PR](https://github.com/microsoft/onnxruntime/pull/16490)~~, but is waiting for upstream merge~~.
 
 ##### Issue #0 [Closed]
-Updated on 2023.06.08  
+Update on 2023.06.08  
 This [PR](https://github.com/microsoft/onnxruntime/pull/14731) introduced a missing registration of CANN Identity operator for version greater than 14. It has been fixed in this [PR](https://github.com/microsoft/onnxruntime/pull/16210).


### PR DESCRIPTION
Update the CANN CI failure status, and track the upstream merge progress.