### PR TITLE
[CI] Do not run onnx workflow in forked repos

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-test:
     name: Build and test onnx runtime from source
-    if: ${{ contains(github.event.comment.body, 'recheck') || github.event_name == 'schedule' }}
+    if: ${{ github.repository_owner == 'Ascend' && (contains(github.event.comment.body, 'recheck') || github.event_name == 'schedule') }}
     runs-on: ONNXRuntime
     defaults:
       run:


### PR DESCRIPTION
No runner named `ONNXRuntime` in forked repos, so it's no need to run workflow on it.

See: https://github.com/shink/Ascend-CI/actions/runs/13135327329

cc: @xuedinge233 